### PR TITLE
remove data_files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,10 +134,6 @@ setup(
 	python_requires='>=3.6',
 	install_requires=parse_requirements('requirements.txt'),
 
-	data_files=[
-		('', ['README.md', 'requirements.txt'])
-	],
-
 	cmdclass={
 		'install': LocalInstallCommand,
 		'clean': CleanCommand


### PR DESCRIPTION
`data_files` in `setup.py` does nothing and pollutes /usr/local with README.md and requirements.txt.
```
/usr/local$ ls
bin  etc  games  include  lib  man  README.md  requirements.txt  sbin  share  src
```