### PR TITLE
corrected file handling in generate_auth_json and added 2 hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ venv.bak/
 
 # Custom files
 TODO.txt
+
+#IntelliJ folder
+.idea/*
+
+#my auth folder
+auth.json

--- a/usbrip/__main__.py
+++ b/usbrip/__main__.py
@@ -354,8 +354,9 @@ def _validate_io_args(args):
 		elif not os.path.isfile(args.input):
 			usbrip_arg_error(args.input + ': Not a regular file')
 
-	if hasattr(args, 'output') and os.path.exists(args.output):
-		usbrip_arg_error(args.output + ': Path already exists')
+	# TODO seems to be only relevant for generate_auth call - if so => remove
+	# if hasattr(args, 'output') and os.path.exists(args.output):
+	# 	usbrip_arg_error(args.output + ': Path already exists')
 
 
 def _validate_attribute_args(args):


### PR DESCRIPTION
The generate_auth_json method in "usbrip/lib/core/usbevents" seems to was inteded to append to a already existing file and still contained some debug entries.
This behavior was now improved, so that the genauth arg can be used to add additional entries to the auth file.